### PR TITLE
Add release notes description and link

### DIFF
--- a/Release-Notes/README.md
+++ b/Release-Notes/README.md
@@ -2,7 +2,7 @@ Here are some release notes I compiled and published for public consumption:
 
 https://github.com/CitrineInformatics/citrine-python/releases/tag/v1.6.0
 
-(Citrine Python)[https://citrineinformatics.github.io/citrine-python/index.html]
+[Citrine Python](https://citrineinformatics.github.io/citrine-python/index.html)
 is an open-source Python library used in materials informatics research.
 To compile the notes, I read the pull requests, JIRA tickets, and
 design docs associated with each commit message entering the release. Whenever

--- a/Release-Notes/README.md
+++ b/Release-Notes/README.md
@@ -1,8 +1,10 @@
-Here are some release notes I compiled and published for public consumption.
-Citrine Python is an open-source Python library used in computational materials
-informatics. To compile the notes, I read the pull requests, JIRA tickets, and
+Here are some release notes I compiled and published for public consumption:
+
+https://github.com/CitrineInformatics/citrine-python/releases/tag/v1.6.0
+
+(Citrine Python)[https://citrineinformatics.github.io/citrine-python/index.html]
+is an open-source Python library used in materials informatics research.
+To compile the notes, I read the pull requests, JIRA tickets, and
 design docs associated with each commit message entering the release. Whenever
 I needed clarification, I reached out to the lead engineer of that feature or
 bugfix. Most questions were answered efficiently over Slack.
-
-https://github.com/CitrineInformatics/citrine-python/releases/tag/v1.6.0

--- a/Release-Notes/README.md
+++ b/Release-Notes/README.md
@@ -1,0 +1,8 @@
+Here are some release notes I compiled and published for public consumption.
+Citrine Python is an open-source Python library used in computational materials
+informatics. To compile the notes, I read the pull requests, JIRA tickets, and
+design docs associated with each commit message entering the release. Whenever
+I needed clarification, I reached out to the lead engineer of that feature or
+bugfix. Most questions were answered efficiently over Slack.
+
+https://github.com/CitrineInformatics/citrine-python/releases/tag/v1.6.0


### PR DESCRIPTION
This pull request adds information on example release notes I published while working at Citrine. 