### PR TITLE
Add information on documentation code review

### DIFF
--- a/Documentation-Code-Review/README.md
+++ b/Documentation-Code-Review/README.md
@@ -1,7 +1,9 @@
 This is a code review of a major documentation change that I participated in
-during my last job. My teammate had to update the documentation after adding a
+during my last job:
+
+https://github.com/CitrineInformatics/citrine-python/pull/710
+
+My teammate had to update the documentation after adding a
 large feature and deprecating several outdated features.
 The [code base](https://github.com/CitrineInformatics/citrine-python)
 is an open source tool used in materials informatics research.
-
-https://github.com/CitrineInformatics/citrine-python/pull/710

--- a/Documentation-Code-Review/README.md
+++ b/Documentation-Code-Review/README.md
@@ -1,0 +1,7 @@
+This is a code review of a major documentation change that I participated in
+during my last job. My teammate had to update the documentation after adding a
+large feature and deprecating several outdated features.
+The [code base](https://github.com/CitrineInformatics/citrine-python)
+is an open source tool used in materials informatics research.
+
+https://github.com/CitrineInformatics/citrine-python/pull/710


### PR DESCRIPTION
This pull request adds a link to a short description of a major documentation code review I participated in while working at Citrine.